### PR TITLE
Update LTS release.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/ukhomeofficedigital/centos-base
 
 WORKDIR /opt/nodejs
-ENV NODE_VERSION v6.11.0
+ENV NODE_VERSION v6.11.1
 
 RUN groupadd -r nodejs && \
     useradd -r -g nodejs nodejs -d /app && \


### PR DESCRIPTION
This includes the fix for the latest hash flooding vulnerability

https://nodejs.org/en/blog/vulnerability/july-2017-security-releases/