### PR TITLE
Simplify image_to_quay script

### DIFF
--- a/bin/image_to_quay.sh
+++ b/bin/image_to_quay.sh
@@ -1,27 +1,24 @@
 #!/bin/sh
 
 #get node version from dockerfile
-NODE_VERSION=$(grep "ENV NODE_VERSION" Dockerfile | sed 's/^ENV NODE_VERSION v//')
-
-#get major, minor and patch
-MAJOR=`echo $NODE_VERSION | awk '{split($0,a,"."); print a[1]}'`
-MINOR=`echo $NODE_VERSION | awk '{split($0,a,"."); print a[2]}'`
-PATCH=`echo $NODE_VERSION | awk '{split($0,a,"."); print a[3]}'`
+PATCH=$(grep "ENV NODE_VERSION" Dockerfile | awk -F ' ' '{print $NF}')
+MINOR=`echo ${PATCH} | awk -F '.' '{print $1"."$2}'`
+MAJOR=`echo ${MINOR} | awk -F '.' '{print $1}'`
 
 docker login -u="ukhomeofficedigital+drone" -p="${DOCKER_PASSWORD}" quay.io
 
 tag_n_push() {
-  echo "Publishing v${1} of nodejs-base..."
-  docker tag nodejs-base "quay.io/ukhomeofficedigital/nodejs-base:v${1}"
-  docker push "quay.io/ukhomeofficedigital/nodejs-base:v${1}"
-  echo "published v${1}"
+  echo "Publishing ${1} of nodejs-base..."
+  docker tag nodejs-base "quay.io/ukhomeofficedigital/nodejs-base:${1}"
+  docker push "quay.io/ukhomeofficedigital/nodejs-base:${1}"
+  echo "published ${1}"
 }
 
 #major, minor patch version
-tag_n_push "${MAJOR}.${MINOR}.${PATCH}"
+tag_n_push "${PATCH}"
 
 #major, minor version
-tag_n_push "${MAJOR}.${MINOR}"
+tag_n_push "${MINOR}"
 
 #major
 tag_n_push "${MAJOR}"

--- a/bin/image_to_quay.sh
+++ b/bin/image_to_quay.sh
@@ -1,29 +1,27 @@
 #!/bin/sh
 
 #get node version from dockerfile
-NODE_VERSION=$(grep "ENV NODE_VERSION" Dockerfile | sed 's/^ENV NODE_VERSION v//');
+NODE_VERSION=$(grep "ENV NODE_VERSION" Dockerfile | sed 's/^ENV NODE_VERSION v//')
 
 #get major, minor and patch
-MAJOR=`echo $NODE_VERSION | awk '{split($0,a,"."); print a[1]}'`;
-MINOR=`echo $NODE_VERSION | awk '{split($0,a,"."); print a[2]}'`;
-PATCH=`echo $NODE_VERSION | awk '{split($0,a,"."); print a[3]}'`;
+MAJOR=`echo $NODE_VERSION | awk '{split($0,a,"."); print a[1]}'`
+MINOR=`echo $NODE_VERSION | awk '{split($0,a,"."); print a[2]}'`
+PATCH=`echo $NODE_VERSION | awk '{split($0,a,"."); print a[3]}'`
 
-docker login -u="ukhomeofficedigital+drone" -p=${DOCKER_PASSWORD} quay.io;
+docker login -u="ukhomeofficedigital+drone" -p="${DOCKER_PASSWORD}" quay.io
+
+tag_n_push() {
+  echo "Publishing v${1} of nodejs-base..."
+  docker tag nodejs-base "quay.io/ukhomeofficedigital/nodejs-base:v${1}"
+  docker push "quay.io/ukhomeofficedigital/nodejs-base:v${1}"
+  echo "published v${1}"
+}
 
 #major, minor patch version
-echo "Publishing v${MAJOR}.${MINOR}.${PATCH} of nodejs-base...";
-docker tag nodejs-base quay.io/ukhomeofficedigital/nodejs-base:v${MAJOR}.${MINOR}.${PATCH}
-docker push quay.io/ukhomeofficedigital/nodejs-base:v${MAJOR}.${MINOR}.${PATCH}
-echo "published v${MAJOR}.${MINOR}.${PATCH}";
+tag_n_push "${MAJOR}.${MINOR}.${PATCH}"
 
 #major, minor version
-echo "Publishing v${MAJOR}.${MINOR} of nodejs-base";
-docker tag nodejs-base quay.io/ukhomeofficedigital/nodejs-base:v${MAJOR}.${MINOR}
-docker push quay.io/ukhomeofficedigital/nodejs-base:v${MAJOR}.${MINOR}
-echo "published v${MAJOR}.${MINOR}";
+tag_n_push "${MAJOR}.${MINOR}"
 
 #major
-echo "Publishing v${MAJOR} of nodejs-base";
-docker tag nodejs-base quay.io/ukhomeofficedigital/nodejs-base:v${MAJOR};
-docker push quay.io/ukhomeofficedigital/nodejs-base:v${MAJOR};
-echo "published v${MAJOR}";
+tag_n_push "${MAJOR}"


### PR DESCRIPTION
Separated the tag and push actions into a helper function to help reduce repetitive code.
Simplified the extraction and handling of the `node` version.