### PR TITLE
Use latest LTS node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/ukhomeofficedigital/centos-base
 
 WORKDIR /opt/nodejs
-ENV NODE_VERSION v6.11.1
+ENV NODE_VERSION v8.9.4
 
 RUN groupadd -r nodejs && \
     useradd -r -g nodejs nodejs -d /app && \


### PR DESCRIPTION
`node@8` is now the most recent LTS, so make that available to applications to deploy with.