### PR TITLE
Fix: Set UID to the correct number for v8 series

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /opt/nodejs
 ENV NODE_VERSION v8.9.4
 
 RUN groupadd -r nodejs && \
-    useradd -r -u 998 -g nodejs nodejs -d /app && \
+    useradd -r -u 999 -g nodejs nodejs -d /app && \
     mkdir -p /opt/nodejs /app && \
     chown -R nodejs:nodejs /app && \
     yum install -y curl && yum clean all && rpm --rebuilddb && \


### PR DESCRIPTION
The latest v8 images have had a UID of 999 and not 998 like the v6
images.