### PR TITLE
Add version for latest 6.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/ukhomeofficedigital/centos-base
 
 WORKDIR /opt/nodejs
-ENV NODE_VERSION v8.11.1
+ENV NODE_VERSION v6.14.2
 
 RUN groupadd -r nodejs && \
     useradd -r -u 999 -g nodejs nodejs -d /app && \


### PR DESCRIPTION
`ircbd` uses NodeJS version 6.
At the moment, the v6 images on Quay are broken with that file system issue:
> filesystem-3.2-20.el7.x86_64 was supposed to be removed but is not!

This commit changes the NodeJS version to the latest v6 version.
It looks like it needs to be merged to master for Quay to pick it up?