### PR TITLE
Use latest npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN groupadd -r nodejs && \
     yum install -y curl && yum clean all && rpm --rebuilddb && \
     curl https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz | tar xz --strip-components=1
 
+RUN npm install -g npm@6
+
 ENV PATH=${PATH}:/opt/nodejs/bin
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,10 @@ RUN groupadd -r nodejs && \
     yum install -y curl && yum clean all && rpm --rebuilddb && \
     curl https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz | tar xz --strip-components=1
 
+ENV PATH=${PATH}:/opt/nodejs/bin
+
 RUN npm install -g npm@6
 
-ENV PATH=${PATH}:/opt/nodejs/bin
 WORKDIR /app
 
 ONBUILD RUN yum clean all && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN groupadd -r nodejs && \
 
 ENV PATH=${PATH}:/opt/nodejs/bin
 
-RUN npm install -g npm@6
+RUN /opt/nodejs/bin/npm install -g npm@6
 
 WORKDIR /app
 


### PR DESCRIPTION
npm@6 allows for use of `npm ci` command which will install _strictly_ the dependencies as per the package-lock in a project and will fail if the package-lock and package.json are inconsistent. 

This provides enhanced security for deployments as it gives precise control over the exact versions of the full dependency tree.